### PR TITLE
Exclude RegExp strings in injection

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -1,7 +1,7 @@
 'name': 'Hyperlink'
 'scopeName': 'text.hyperlink'
 'fileTypes': []
-'injectionSelector': 'text, string, comment, source.gfm'
+'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
 'patterns': [
   {
     'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)[-:@[:word:].,~%+/?=&#;|!]+(?<![-.,?:#;])'

--- a/spec/fixtures/test-grammar.cson
+++ b/spec/fixtures/test-grammar.cson
@@ -1,0 +1,11 @@
+'name': 'TestGrammar'
+'scopeName': 'source.test'
+'fileTypes': []
+'patterns': [
+  {
+    'captures':
+      '1':
+        'name': 'string.regexp.test'
+    'match': 'regexp:(.+)'
+  }
+]

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -23,3 +23,10 @@ describe 'Hyperlink grammar', ->
 
     {tokens} = plainGrammar.tokenizeLine 'http://twitter.com/#!/AtomEditor'
     expect(tokens[0]).toEqual value: 'http://twitter.com/#!/AtomEditor', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
+
+  it 'does not parse links in a regex string', ->
+    path = require 'path'
+    testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures/test-grammar.cson'))
+
+    {tokens} = testGrammar.tokenizeLine 'regexp:http://github.com'
+    expect(tokens[1]).toEqual value: 'http://github.com', scopes: ['source.test', 'string.regexp.test']


### PR DESCRIPTION
This fixes https://github.com/atom/language-perl/issues/46

See https://github.com/textmate/hyperlink-helper.tmbundle/commit/536b48db9d3ba3d8c9e694abd64cd8caba2bc640