### PR TITLE
Add CFML compatibility

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -4,7 +4,7 @@
 'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
 'patterns': [
   {
-    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)[-:@[:word:].,~%+/?=&#;|!]+(?<![-.,?:#;])'
+    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[a-zA-Z0-9]*\\#))(?:[-:@a-zA-Z0-9.,~%+\/?=&#;|!]))+(?<![-.,?:#;])'
     'name': 'markup.underline.link.$2.hyperlink'
   }
   {

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -31,3 +31,15 @@ describe 'Hyperlink grammar', ->
 
     {tokens} = testGrammar.tokenizeLine 'regexp:http://github.com'
     expect(tokens[1]).toEqual value: 'http://github.com', scopes: ['source.test', 'string.regexp.test']
+
+  describe 'parsing cfml strings', ->
+
+    it 'does not include anything between (and including) \\# signs', ->
+        plainGrammar = atom.grammars.selectGrammar()
+        {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'
+        expect(tokens[0]).toEqual value: 'http://github.com/', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
+
+    it 'still includes single \\# signs', ->
+        plainGrammar = atom.grammars.selectGrammar()
+        {tokens} = plainGrammar.tokenizeLine 'http://github.com/atom/#start-of-content'
+        expect(tokens[0]).toEqual value: 'http://github.com/atom/#start-of-content', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -34,12 +34,12 @@ describe 'Hyperlink grammar', ->
 
   describe 'parsing cfml strings', ->
 
-    it 'does not include anything between (and including) \\# signs', ->
+    it 'does not include anything between (and including) pound signs', ->
       plainGrammar = atom.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'
       expect(tokens[0]).toEqual value: 'http://github.com/', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
 
-    it 'still includes single \\# signs', ->
+    it 'still includes single pound signs', ->
       plainGrammar = atom.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/atom/#start-of-content'
       expect(tokens[0]).toEqual value: 'http://github.com/atom/#start-of-content', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -35,11 +35,11 @@ describe 'Hyperlink grammar', ->
   describe 'parsing cfml strings', ->
 
     it 'does not include anything between (and including) \\# signs', ->
-        plainGrammar = atom.grammars.selectGrammar()
-        {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'
-        expect(tokens[0]).toEqual value: 'http://github.com/', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
+      plainGrammar = atom.grammars.selectGrammar()
+      {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'
+      expect(tokens[0]).toEqual value: 'http://github.com/', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
 
     it 'still includes single \\# signs', ->
-        plainGrammar = atom.grammars.selectGrammar()
-        {tokens} = plainGrammar.tokenizeLine 'http://github.com/atom/#start-of-content'
-        expect(tokens[0]).toEqual value: 'http://github.com/atom/#start-of-content', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
+      plainGrammar = atom.grammars.selectGrammar()
+      {tokens} = plainGrammar.tokenizeLine 'http://github.com/atom/#start-of-content'
+      expect(tokens[0]).toEqual value: 'http://github.com/atom/#start-of-content', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']


### PR DESCRIPTION
Add CFML compatibility by not capturing `#` if there is another `#` in the
URL string.