### PR TITLE
prevent multiple `#` from matching as valid url

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -4,7 +4,7 @@
 'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
 'patterns': [
   {
-    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[a-zA-Z0-9]*\\#))(?:[-:@a-zA-Z0-9.,~%+\/?=&#;|!]))+(?<![-.,?:#;])'
+    'match': '(?x)(?:(?!(?:.+\\#){2,})( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue):\/\/|mailto:)[-:@[:word:].,~%+\/?=&#;|!]+(?<![-.,?:#;]))'
     'name': 'markup.underline.link.$2.hyperlink'
   }
   {

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -34,10 +34,15 @@ describe 'Hyperlink grammar', ->
 
   describe 'parsing cfml strings', ->
 
-    it 'does not include anything between (and including) pound signs', ->
+    it 'does not include link containing 2 pound signs', ->
       plainGrammar = atom.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'
-      expect(tokens[0]).toEqual value: 'http://github.com/', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
+      expect(tokens[0]).toEqual value: 'http://github.com/#username#', scopes: ['text.plain.null-grammar']
+
+    it 'does not include link containing more than 2 pound signs', ->
+      plainGrammar = atom.grammars.selectGrammar()
+      {tokens} = plainGrammar.tokenizeLine 'http://#domain#/#username#'
+      expect(tokens[0]).toEqual value: 'http://#domain#/#username#', scopes: ['text.plain.null-grammar']
 
     it 'still includes single pound signs', ->
       plainGrammar = atom.grammars.selectGrammar()


### PR DESCRIPTION
This prevents URLs from being matched when they have multiple pounds in the URL. 

For example, this link should not be matched:
CFML: `setBaseURL("http://#cgi.HTTP_HOST#/#getSetting('AppMapping')#/");`

I reverted to old regex from 0c9bbc7, and added a negative lookahead to prevent multiple pound symbols in a URL. To prevent from throwing off cfml syntax.

Reference for previous PR: #5

Also reference to the issue from atuttle/atom-language-cfml#60

The main question I have is should it match the first part of the URL up until the first `#` if there are multiple.

won't match:
- http://github.com/#username#
- http://#domain#/#username#

will match
- http://github.com/atom/#start-of-content
- http://github.com/atom/
