### PR TITLE
Allows unicode characters in links (again)

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -4,7 +4,7 @@
 'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
 'patterns': [
   {
-    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[a-zA-Z0-9]*\\#))(?:[-:@a-zA-Z0-9.,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
+    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
     'name': 'markup.underline.link.$2.hyperlink'
   }
   {

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -29,8 +29,11 @@ describe 'Hyperlink grammar', ->
     {tokens} = plainGrammar.tokenizeLine 'https://github.com/atom/brightray_example'
     expect(tokens[0]).toEqual value: 'https://github.com/atom/brightray_example', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
+  it 'parses http: and https: links that contains unicode characters', ->
+    plainGrammar = atom.grammars.selectGrammar()
+
     {tokens} = plainGrammar.tokenizeLine 'https://sv.wikipedia.org/wiki/Mañana'
-    expect(tokens[0]).toEqual {value: 'https://sv.wikipedia.org/wiki/Mañana', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']}, 'allows unicode characters'
+    expect(tokens[0]).toEqual value: 'https://sv.wikipedia.org/wiki/Mañana', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
   it 'does not parse links in a regex string', ->
     testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -29,6 +29,9 @@ describe 'Hyperlink grammar', ->
     {tokens} = plainGrammar.tokenizeLine 'https://github.com/atom/brightray_example'
     expect(tokens[0]).toEqual value: 'https://github.com/atom/brightray_example', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
+    {tokens} = plainGrammar.tokenizeLine 'https://sv.wikipedia.org/wiki/Mañana'
+    expect(tokens[0]).toEqual {value: 'https://sv.wikipedia.org/wiki/Mañana', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']}, 'allows unicode characters'
+
   it 'does not parse links in a regex string', ->
     testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))
 


### PR DESCRIPTION
Re-add fix for #1 that was originally introduced in commit d457a73 but later removed in PR #5 (without motivation). 