### PR TITLE
Allows bracket characters in links

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -4,7 +4,7 @@
 'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
 'patterns': [
   {
-    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
+    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!()]))+(?<![-.,?:#;])'
     'name': 'markup.underline.link.$2.hyperlink'
   }
   {

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -35,6 +35,12 @@ describe 'Hyperlink grammar', ->
     {tokens} = plainGrammar.tokenizeLine 'https://sv.wikipedia.org/wiki/Mañana'
     expect(tokens[0]).toEqual value: 'https://sv.wikipedia.org/wiki/Mañana', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
+  it 'parses links that contains bracket characters', ->
+    plainGrammar = atom.grammars.selectGrammar()
+
+    {tokens} = plainGrammar.tokenizeLine 'https://en.wikipedia.org/wiki/Brackets_(text_editor)'
+    expect(tokens[0]).toEqual value: 'https://en.wikipedia.org/wiki/Brackets_(text_editor)', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
+
   it 'does not parse links in a regex string', ->
     testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))
 


### PR DESCRIPTION
Hi there!
Links with bracket characters must be a valid URI https://tools.ietf.org/html/rfc3986#section-2.2

Before: 
https://www.dropbox.com/s/ct2d8rk65zwp4st/Screenshot%202016-11-16%2000.23.48.png?dl=0

Just add () to the regular expression and spec.