### PR TITLE
PHP and mailto fixes

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -4,8 +4,12 @@
 'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
 'patterns': [
   {
-    'match': '(?x)( (https?|s?ftp|ftps|file|smb|afp|nfs|(x-)?man(-page)?|gopher|txmt|issue)://|mailto:)((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
-    'name': 'markup.underline.link.$2.hyperlink'
+    'match': '(?x)\\b(https?|s?ftp|ftps|file|smb|afp|nfs|(?:x-)?man(?:-page)?|gopher|txmt|issue)://((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
+    'name': 'markup.underline.link.$1.hyperlink'
+  }
+  {
+    'match': '(?x)\\b(mailto):((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
+    'name': 'markup.underline.link.$1.hyperlink'
   }
   {
     'match': '(?i)\\bRFC(?: |(?<= RFC))(\\d+)\\b'

--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -1,7 +1,7 @@
 'name': 'Hyperlink'
 'scopeName': 'text.hyperlink'
 'fileTypes': []
-'injectionSelector': 'text, string -string.regexp, comment, source.gfm'
+'injectionSelector': 'text - string.regexp, string - string.regexp, comment, source.gfm'
 'patterns': [
   {
     'match': '(?x)\\b(https?|s?ftp|ftps|file|smb|afp|nfs|(?:x-)?man(?:-page)?|gopher|txmt|issue)://((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -35,6 +35,15 @@ describe 'Hyperlink grammar', ->
     {tokens} = plainGrammar.tokenizeLine 'https://sv.wikipedia.org/wiki/Mañana'
     expect(tokens[0]).toEqual value: 'https://sv.wikipedia.org/wiki/Mañana', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
+  it 'parses other links', ->
+    plainGrammar = atom.grammars.selectGrammar()
+    
+    {tokens} = plainGrammar.tokenizeLine 'mailto:noreply@example.com'
+    expect(tokens[0]).toEqual value: 'mailto:noreply@example.com', scopes: ['text.plain.null-grammar', 'markup.underline.link.mailto.hyperlink']
+
+    {tokens} = plainGrammar.tokenizeLine 'x-man-page://tar'
+    expect(tokens[0]).toEqual value: 'x-man-page://tar', scopes: ['text.plain.null-grammar', 'markup.underline.link.x-man-page.hyperlink']
+    
   it 'does not parse links in a regex string', ->
     testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))
 

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -50,8 +50,23 @@ describe 'Hyperlink grammar', ->
     {tokens} = testGrammar.tokenizeLine 'regexp:http://github.com'
     expect(tokens[1]).toEqual value: 'http://github.com', scopes: ['source.test', 'string.regexp.test']
 
-  describe 'parsing cfml strings', ->
+  describe 'parsing PHP strings', ->
+    it 'does not parse links in a regex string', ->
+      # PHP is unique in that its root scope is `text.html.php`, meaning that even though
+      # `string - string.regexp` won't match in a regex string, `text` still will.
+      # This is the reason the injection selector is `text - string.regexp` instead.
+      # https://github.com/atom/language-php/issues/219
 
+      waitsForPromise ->
+        atom.packages.activatePackage('language-php')
+
+      runs ->
+        phpGrammar = atom.grammars.grammarForScopeName('text.html.php')
+
+        {tokens} = phpGrammar.tokenizeLine '<?php "/mailto:/" ?>'
+        expect(tokens[3]).toEqual value: 'mailto:', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'string.regexp.double-quoted.php']
+
+  describe 'parsing cfml strings', ->
     it 'does not include anything between (and including) pound signs', ->
       plainGrammar = atom.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR includes two changes, kindly separated into two commits.
* Fix for `mailto`'s scope, which previously was `markup.underline.link..hyperlink`.  It is now `markup.underline.link.mailto.hyperlink`, as expected.
* Do not match links in regexes, even in text grammars.  This fixes a PHP bug where links were still being matched despite the `string - string.regexp` portion because of the root `text.html.php` scope and the `text` injection selector.

### Alternate Designs

None.

### Benefits

See changes.

### Possible Drawbacks

None.

### Applicable Issues

Fixes atom/language-php#219