### PR TITLE
Hide "Hyperlink" from grammar-selector menu

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -1,6 +1,4 @@
-'name': 'Hyperlink'
 'scopeName': 'text.hyperlink'
-'fileTypes': []
 'injectionSelector': 'text - string.regexp, string - string.regexp, comment, source.gfm'
 'patterns': [
   {


### PR DESCRIPTION
(Copied from [`atom/language-todo#65`](https://github.com/atom/language-todo/pull/65))

-----------------------------------------

### Description of the Change

Follow-up of [`atom/grammar-selector#34`][1], which patched the `grammar-selector` package to hide "internal" or injection-specific grammars from the selection menu. This was recently merged and released in [`grammar-selector@0.49.6`](https://github.com/atom/grammar-selector/tree/v0.49.6). It's now safe to cut redundant `name` fields from grammars which shouldn't be listed alongside "real" languages.

See [`atom/grammar-selector#34`][1] for the original discussion.

/cc @50Wliu

[1]: https://github.com/atom/grammar-selector/pull/34