### PR TITLE
allow single matching parens

### DIFF
--- a/grammars/hyperlink.cson
+++ b/grammars/hyperlink.cson
@@ -2,7 +2,7 @@
 'injectionSelector': 'text - string.regexp, string - string.regexp, comment, source.gfm'
 'patterns': [
   {
-    'match': '(?x)\\b(https?|s?ftp|ftps|file|smb|afp|nfs|(?:x-)?man(?:-page)?|gopher|txmt|issue|atom)://((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]))+(?<![-.,?:#;])'
+    'match': '(?x)\\b(https?|s?ftp|ftps|file|smb|afp|nfs|(?:x-)?man(?:-page)?|gopher|txmt|issue|atom)://((?!(\\#[[:word:]]*\\#))(?:[-:@[:word:].,~%+_\/?=&#;|!]|\\((?:(?!(\\#[[:word:]]*\\#))[-:@[:word:].,~%+_\/?=&#;|!])*\\)))+(?<![-.,?:#;])'
     'name': 'markup.underline.link.$1.hyperlink'
   }
   {

--- a/spec/hyperlink-spec.coffee
+++ b/spec/hyperlink-spec.coffee
@@ -37,7 +37,7 @@ describe 'Hyperlink grammar', ->
 
   it 'parses other links', ->
     plainGrammar = atom.grammars.selectGrammar()
-    
+
     {tokens} = plainGrammar.tokenizeLine 'mailto:noreply@example.com'
     expect(tokens[0]).toEqual value: 'mailto:noreply@example.com', scopes: ['text.plain.null-grammar', 'markup.underline.link.mailto.hyperlink']
 
@@ -46,7 +46,7 @@ describe 'Hyperlink grammar', ->
 
     {tokens} = plainGrammar.tokenizeLine 'atom://core/open/file?filename=urlEncodedFileName&line=n&column=n'
     expect(tokens[0]).toEqual value: 'atom://core/open/file?filename=urlEncodedFileName&line=n&column=n', scopes: ['text.plain.null-grammar', 'markup.underline.link.atom.hyperlink']
-    
+
   it 'does not parse links in a regex string', ->
     testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))
 
@@ -79,3 +79,14 @@ describe 'Hyperlink grammar', ->
       plainGrammar = atom.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/atom/#start-of-content'
       expect(tokens[0]).toEqual value: 'http://github.com/atom/#start-of-content', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
+
+  describe 'parsing matching parentheses', ->
+    it 'still includes matching parentheses', ->
+      plainGrammar = atom.grammars.selectGrammar()
+      {tokens} = plainGrammar.tokenizeLine 'https://en.wikipedia.org/wiki/Atom_(text_editor)'
+      expect(tokens[0]).toEqual value: 'https://en.wikipedia.org/wiki/Atom_(text_editor)', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
+
+    it 'does not include wrapping parentheses', ->
+      plainGrammar = atom.grammars.selectGrammar()
+      {tokens} = plainGrammar.tokenizeLine '(https://en.wikipedia.org/wiki/Atom_(text_editor))'
+      expect(tokens[1]).toEqual value: 'https://en.wikipedia.org/wiki/Atom_(text_editor)', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']


### PR DESCRIPTION
### Description of the Change

Allow non-nested matching parentheses

`https://en.wikipedia.org/wiki/Atom_(text_editor)`

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits

A lot of wikipedia pages will be correct

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

closes #13
fixes #24 

<!-- Enter any applicable Issues here -->
